### PR TITLE
Move ctx params initialization to GenomeAnnotationCore

### DIFF
--- a/lib/Bio/P3/GenomeAnnotationApp/GenomeAnnotationCore.pm
+++ b/lib/Bio/P3/GenomeAnnotationApp/GenomeAnnotationCore.pm
@@ -38,6 +38,12 @@ sub new
 
     $self->init_service();
 
+    #
+    # Stash a copy of the parameters in the service context for those
+    # methods that need to dip into them for special processing.
+    #
+    $self->ctx->{params} = $self->params;
+
     return $self;
 }
 

--- a/service-scripts/App-GenomeAnnotation.pl
+++ b/service-scripts/App-GenomeAnnotation.pl
@@ -254,12 +254,7 @@ sub process_genome
     $core->impl->add_contigs($genome, \@contigs);
 
     local $Bio::KBase::GenomeAnnotation::Service::CallContext = $core->ctx;
-    #
-    # We stash a copy of the parameters for those methods that
-    # need to dip into them for special processing.
-    #
-    $core->ctx->{params} = $params;
-    
+
     my $result;
 
     #


### PR DESCRIPTION
Moves the stashing of user parameters into $ctx->{params} from App-GenomeAnnotation.pl into GenomeAnnotationCore::new(). This ensures all scripts using GenomeAnnotationCore (including App-GenomeAnnotationGenbank.pl) automatically have the parameters available in the service context for methods like import_sra_metadata, compute_sars2_variation, and call_features_lowvan that depend on them.